### PR TITLE
config: disable logs for wrong pasword attempts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,8 +9,8 @@ openkm_admin_username: 'okmAdmin'
 #openkm_admin_password: 'changeIfYouCare'
 # WARN: Read carefully the Changelog it might have manual upgrade steps.
 openkm_version: '8.1.7'
-openkm_root_log_level: 'error'
-openkm_log_login_attempts: false
+# Keep OFF, otherwise it will show wrong password attempts in the log in plain text
+openkm_root_log_level: 'off'
 openkm_allowed_networks: [' 10.0.0.0/8', '172.16.0.0/16']
 openkm_max_file_size_mb: 100 # MB
 

--- a/templates/config/logback.xml
+++ b/templates/config/logback.xml
@@ -4,7 +4,8 @@
   <logger name="org.hibernate.SQL" level="INFO" />
   <logger name="org.hibernate.type.descriptor.sql" level="INFO" />
   <logger name="ch.qos.logback" level="WARN" />
-  <logger name="com.openkm" level="INFO" />
+  <!-- Keep OFF, otherwise it will show wrong password attempts in the log in plain text -->
+  <logger name="com.openkm" level="OFF" />
   <logger name="com.openkm.util.DocConverter" level="INFO" />
   <logger name="com.openkm.util.ExecutionUtils" level="INFO" />
   
@@ -15,10 +16,6 @@
   <logger name="com.openkm.module.db.base.BaseNotificationModule" level="INFO" />
   <logger name="com.openkm.principal.PrincipalUtils" level="INFO" />
   
-{% if not openkm_log_login_attempts %}
-  <!-- Disable printing passwords in logs. -->
-  <logger name="org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter" level="OFF" />
-{% endif %}
   <logger name="org.springframework.jdbc" level="INFO" />
   <logger name="org.springframework.orm.jpa" level="INFO" />
   <logger name="org.springframework.transaction" level="INFO" />


### PR DESCRIPTION
This should be kept:
```
logging.level.root=OFF
```

And this one can be missing, but better to keep it OFF, so it's clear:
```
<logger name="com.openkm" level="OFF" />
```